### PR TITLE
第三回Go勉強会の宿題

### DIFF
--- a/http_server/echo/Makefile
+++ b/http_server/echo/Makefile
@@ -17,3 +17,6 @@ square_bad_request:
 
 incr:
 	curl -X POST localhost:8080/incr -H 'Content-Type: application/json' -d '{"num":3}'
+
+failed_incr:
+	curl -X GET localhost:8080/incr -H 'Content-Type: application/json' -d '{"num":3}'

--- a/http_server/echo/Makefile
+++ b/http_server/echo/Makefile
@@ -20,3 +20,6 @@ incr:
 
 failed_incr:
 	curl -X GET localhost:8080/incr -H 'Content-Type: application/json' -d '{"num":3}'
+
+decr:
+	curl -X DELETE localhost:8080/decr -H 'Content-Type: application/json' -d '{"num":3}'

--- a/http_server/echo/Makefile
+++ b/http_server/echo/Makefile
@@ -22,4 +22,4 @@ failed_incr:
 	curl -X GET localhost:8080/incr -H 'Content-Type: application/json' -d '{"num":3}'
 
 decr:
-	curl -X DELETE localhost:8080/decr -H 'Content-Type: application/json' -d '{"num":3}'
+	curl -X POST localhost:8080/decr -H 'Content-Type: application/json' -d '{"num":3}'

--- a/http_server/echo/main.go
+++ b/http_server/echo/main.go
@@ -25,7 +25,7 @@ func main() {
 	// POST Bodyの読み込み
 	e.POST("/incr", incrementHandler)
 	// DELETE Bodyの読み込み
-	e.DELETE("/decr", decrementHandler)
+	e.POST("/decr", decrementHandler)
 
 	// 8080ポートで起動
 	e.Logger.Fatal(e.Start(":8080"))

--- a/http_server/echo/main.go
+++ b/http_server/echo/main.go
@@ -24,6 +24,8 @@ func main() {
 	e.GET("/square", squareHandler)
 	// POST Bodyの読み込み
 	e.POST("/incr", incrementHandler)
+	// DELETE Bodyの読み込み
+	e.DELETE("/decr", decrementHandler)
 
 	// 8080ポートで起動
 	e.Logger.Fatal(e.Start(":8080"))
@@ -66,7 +68,17 @@ func incrementHandler(c echo.Context) error {
 	if err := c.Bind(&incrRequest); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Internal Server Error")
 	}
-	counter += incrRequest.Num
+	counter = countCalculator(incrRequest, "increment")
+	return c.String(http.StatusOK, fmt.Sprintf("Value of Counter is %d \n", counter))
+}
+
+// Bodyから数字を取得してその数字だけCounterをDecrementするハンドラー
+func decrementHandler(c echo.Context) error {
+	var incrRequest incrRequest
+	if err := c.Bind(&incrRequest); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Internal Server Error")
+	}
+	counter = countCalculator(incrRequest, "decrement")
 	return c.String(http.StatusOK, fmt.Sprintf("Value of Counter is %d \n", counter))
 }
 
@@ -82,4 +94,14 @@ func greaterThan100(num int) error {
 		return nil
 	}
 	return fmt.Errorf("failed validation. greater than %d", limit)
+}
+
+func countCalculator(req incrRequest, expression string) int {
+	if expression == "increment" {
+		return counter + req.Num
+	} else if expression == "decrement" {
+		return counter - req.Num
+	} else {
+		return counter
+	}
 }

--- a/http_server/echo/main.go
+++ b/http_server/echo/main.go
@@ -69,7 +69,10 @@ func incrementHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Internal Server Error")
 	}
 	counter = countCalculator(incrRequest, "increment")
-	return c.String(http.StatusOK, fmt.Sprintf("Value of Counter is %d \n", counter))
+	res := &counterResponse{
+		Counter: counter,
+	}
+	return c.JSON(http.StatusOK, res)
 }
 
 // Bodyから数字を取得してその数字だけCounterをDecrementするハンドラー
@@ -86,6 +89,10 @@ type incrRequest struct {
 	// jsonタグをつける事でjsonのunmarshalが出来る
 	// jsonパッケージに渡すので、Publicである必要がある
 	Num int `json:"num"`
+}
+
+type counterResponse struct {
+	Counter int `json:"counter"`
 }
 
 func greaterThan100(num int) error {

--- a/http_server/echo/main.go
+++ b/http_server/echo/main.go
@@ -50,6 +50,11 @@ func squareHandler(c echo.Context) error {
 		// 他のエラーの可能性もあるがサンプルとして纏める
 		return echo.NewHTTPError(http.StatusBadRequest, "num is not integer")
 	}
+
+	if err := greaterThan100(num); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("%v", err))
+	}
+
 	// fmt.Sprintfでフォーマットに沿った文字列を生成できる。
 	return c.String(http.StatusOK, fmt.Sprintf("Square of %d is equal to %d", num, num*num))
 }
@@ -69,4 +74,12 @@ type incrRequest struct {
 	// jsonタグをつける事でjsonのunmarshalが出来る
 	// jsonパッケージに渡すので、Publicである必要がある
 	Num int `json:"num"`
+}
+
+func greaterThan100(num int) error {
+	limit := 100
+	if num < limit {
+		return nil
+	}
+	return fmt.Errorf("failed validation. greater than %d", limit)
 }

--- a/http_server/net_http/Makefile
+++ b/http_server/net_http/Makefile
@@ -17,4 +17,4 @@ incr:
 	curl -X POST localhost:8080/incr -d '{"num":3}'
 
 decr:
-	curl -X DELETE localhost:8080/decr -d '{"num":3}'
+	curl -X POST localhost:8080/decr -d '{"num":3}'

--- a/http_server/net_http/Makefile
+++ b/http_server/net_http/Makefile
@@ -15,3 +15,6 @@ square_bad_request:
 
 incr:
 	curl -X POST localhost:8080/incr -d '{"num":3}'
+
+decr:
+	curl -X DELETE localhost:8080/decr -d '{"num":3}'

--- a/http_server/net_http/main.go
+++ b/http_server/net_http/main.go
@@ -90,7 +90,7 @@ func incrementHandler(w http.ResponseWriter, req *http.Request) {
 
 // Bodyから数字を取得してその数字だけCounterをDecrementするハンドラー
 func decrementHandler(w http.ResponseWriter, req *http.Request) {
-	if err := allowedOnlyDeleteMethod(req); err != nil {
+	if err := allowedOnlyPostMethod(req); err != nil {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		fmt.Fprint(w, fmt.Sprintf("%v", err))
 		return

--- a/http_server/net_http/main.go
+++ b/http_server/net_http/main.go
@@ -52,6 +52,12 @@ func squareHandler(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprint(w, "num is not integer")
 		return
 	}
+
+	if err := greaterThan100(num); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, fmt.Sprintf("%v", err))
+		return
+	}
 	// fmt.Sprintfでフォーマットに沿った文字列を生成できる。
 	fmt.Fprint(w, fmt.Sprintf("Square of %d is equal to %d", num, num*num))
 }
@@ -78,4 +84,12 @@ type incrRequest struct {
 	// jsonタグをつける事でjsonのunmarshalが出来る
 	// jsonパッケージに渡すので、Publicである必要がある
 	Num int `json:"num"`
+}
+
+func greaterThan100(num int) error {
+	limit := 100
+	if num < limit {
+		return nil
+	}
+	return fmt.Errorf("failed validation. greater than %d", limit)
 }

--- a/http_server/net_http/main.go
+++ b/http_server/net_http/main.go
@@ -84,7 +84,7 @@ func incrementHandler(w http.ResponseWriter, req *http.Request) {
 	// BodyのJSONを構造体に変換する
 	json.Unmarshal(buf.Bytes(), &countRequest)
 
-	counter = counterCalculator(countRequest, "increment")
+	counter = countCalculator(countRequest, "increment")
 	fmt.Fprint(w, fmt.Sprintf("Value of Counter is %d \n", counter))
 }
 
@@ -107,7 +107,7 @@ func decrementHandler(w http.ResponseWriter, req *http.Request) {
 	// BodyのJSONを構造体に変換する
 	json.Unmarshal(buf.Bytes(), &countRequest)
 
-	counter = counterCalculator(countRequest, "decrement")
+	counter = countCalculator(countRequest, "decrement")
 	fmt.Fprint(w, fmt.Sprintf("Value of Counter is %d \n", counter))
 }
 
@@ -139,7 +139,7 @@ func allowedOnlyDeleteMethod(req *http.Request) error {
 	return nil
 }
 
-func counterCalculator(req counterRequest, expression string) int {
+func countCalculator(req counterRequest, expression string) int {
 	if expression == "increment" {
 		return counter + req.Num
 	} else if expression == "decrement" {

--- a/http_server/net_http/main.go
+++ b/http_server/net_http/main.go
@@ -65,6 +65,12 @@ func squareHandler(w http.ResponseWriter, req *http.Request) {
 // Bodyから数字を取得してその数字だけCounterをIncrementするハンドラー
 // DBがまだないので簡易的なもの
 func incrementHandler(w http.ResponseWriter, req *http.Request) {
+	if err := onlyPost(req); err != nil {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		fmt.Fprint(w, fmt.Sprintf("%v", err))
+		return
+	}
+
 	body := req.Body
 	// bodyの読み込みに開いたio Readerを最後にCloseする
 	defer body.Close()
@@ -92,4 +98,11 @@ func greaterThan100(num int) error {
 		return nil
 	}
 	return fmt.Errorf("failed validation. greater than %d", limit)
+}
+
+func onlyPost(req *http.Request) error {
+	if req.Method != http.MethodPost {
+		return fmt.Errorf("access not allowed %s", req.Method)
+	}
+	return nil
 }


### PR DESCRIPTION
[第三回資料#課題](https://mf.esa.io/posts/129459#%E8%AA%B2%E9%A1%8C)

## わからなかったところ

`/http_server/echo/main.go` の `incrRequest` をリネームしようとしたところパースエラーになったがそれ以上の情報がなく何故リネームしようとしただけでパースエラーになったかがわからなかった。
`/http_server/net_http/main.go` 側でリネームしたときは大丈夫だった。

