### PR TITLE
第8回Go勉強会の課題@luccafort

### DIFF
--- a/interface/api/interfaces/controllers/user_controller_test.go
+++ b/interface/api/interfaces/controllers/user_controller_test.go
@@ -48,7 +48,7 @@ func newUserContext() echo.Context {
 
 func indexUserContext() echo.Context {
 	e := echo.New()
-	validReq := httptest.NewRequest(http.MethodGet, "/users", strings.NewReader(""))
+	validReq := httptest.NewRequest(http.MethodGet, "/users", nil)
 	validReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	return e.NewContext(validReq, httptest.NewRecorder())
 }

--- a/interface/api/interfaces/controllers/user_controller_test.go
+++ b/interface/api/interfaces/controllers/user_controller_test.go
@@ -18,9 +18,11 @@ type mockUserRepository struct {
 }
 
 var (
-	mockID          = 2
-	userJSON        = `{"first_name":"John ","last_name":"Doe"}`
-	invalidUserJSON = `{"first_name": 1,"last_name": 2}`
+	mockID             = 2
+	userJSON           = `{"first_name":"John ","last_name":"Doe"}`
+	invalidUserJSON    = `{"first_name": 1,"last_name": 2}`
+	emptyFirstNameJSON = `{"first_name": "","last_name": "Doe"}`
+	emptyLastNameJSON  = `{"first_name": "John","last_name": ""}`
 )
 
 func (r *mockUserRepository) Store(db *sqlx.DB, u domain.User) (int, error) {
@@ -44,6 +46,20 @@ func newUserContext() echo.Context {
 func newInvalidUserContext() echo.Context {
 	e := echo.New()
 	invalidReq := httptest.NewRequest(http.MethodPost, "/users", strings.NewReader(invalidUserJSON))
+	invalidReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	return e.NewContext(invalidReq, httptest.NewRecorder())
+}
+
+func newEmptyFirstNameContext() echo.Context {
+	e := echo.New()
+	invalidReq := httptest.NewRequest(http.MethodPost, "/users", strings.NewReader(emptyFirstNameJSON))
+	invalidReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	return e.NewContext(invalidReq, httptest.NewRecorder())
+}
+
+func newEmptyLastNameContext() echo.Context {
+	e := echo.New()
+	invalidReq := httptest.NewRequest(http.MethodPost, "/users", strings.NewReader(emptyLastNameJSON))
 	invalidReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	return e.NewContext(invalidReq, httptest.NewRecorder())
 }
@@ -89,6 +105,24 @@ func TestUserController_Create(t *testing.T) {
 				repository: &mockUserRepository{},
 			},
 			args:    args{c: newInvalidUserContext()},
+			wantErr: true,
+		},
+		{
+			name: "異常系 ユーザ名(FirstName)が空文字のときエラーを返す",
+			fields: fields{
+				db:         nil,
+				repository: &mockUserRepository{isError: true},
+			},
+			args:    args{c: newEmptyFirstNameContext()},
+			wantErr: true,
+		},
+		{
+			name: "異常系 ユーザ名(LastName)が空文字のときエラーを返す",
+			fields: fields{
+				db:         nil,
+				repository: &mockUserRepository{isError: true},
+			},
+			args:    args{c: newEmptyLastNameContext()},
 			wantErr: true,
 		},
 	}

--- a/interface/api/interfaces/database/user_local_repository.go
+++ b/interface/api/interfaces/database/user_local_repository.go
@@ -1,7 +1,10 @@
 package database
 
 import (
+	"fmt"
 	"sync"
+
+	"sort"
 
 	"github.com/jmoiron/sqlx"
 
@@ -40,5 +43,19 @@ func (r *onMemoryUserRepository) Store(db *sqlx.DB, u domain.User) (int, error) 
 // 実装は課題
 // 出来ればuser_id昇順で返す
 func (r *onMemoryUserRepository) FindAll(db *sqlx.DB) (domain.Users, error) {
-	return nil, nil
+	var sortedUsers []domain.User
+	ids := []int{}
+
+	// r.usersから取得するという発想がなくて時間かかってしまった
+	for id := range r.users {
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+	fmt.Printf("sortedKeys: %v", ids)
+
+	for _, id := range ids {
+		sortedUsers = append(sortedUsers, r.users[id])
+	}
+
+	return sortedUsers, nil
 }


### PR DESCRIPTION
- [x] nterfaces/database/user_repository.goのonMemoryUserRepository.FindAllの実装をする。
  - 全ユーザーを返す実装をする。
  - 可能であれば、ユーザーID昇順でSliceを返す。
- [x] TestUserController_Createを修正して、UserController.Createでユーザー名が空でエラーになる箇所のCoverageを通す
- [x] TestUserController_Indexにテストを追加して、UserController.Indexのカバレッジを100%にする。

## 詰まったところ

課題1の `r.users` からIDを取得してソートすればいいと気づくまでに時間がかかった。
DBから実際の値を取得してソートしなければいけないと思い実装していたがコードが長くなりすぎて課題の解説を先に見ていたせいでどうやって短く実装するか？で無駄に悩んでしまった。

テストケースの実装は詰まるところはなかった。